### PR TITLE
Change pomelo.log file permissions

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 
 	log := os.Getenv("HOME") + "/.pomelo.log"
 	msg := fmt.Sprintf("\nNew Entry Date %s\n", now)
-	err := ioutil.WriteFile(log, []byte(msg), 0644)
+	err := ioutil.WriteFile(log, []byte(msg), 0600)
 	if err != nil {
 		fmt.Println("Pomelo could not write to the log file.")
 		os.Exit(1)


### PR DESCRIPTION
I ran `gosec` (a security checker for Golang programs) on Pomelo and it returned this:
```
[<removed>/go/src/github.com/smaraghi/pomelo/main.go:66] - G302: Expect file permissions to be 0600 or less (Confidence: HIGH, Severity: MEDIUM)
  > os.OpenFile(log, os.O_APPEND|os.O_WRONLY, 0644)
```
`gosec` recommends changing the file permissions as `.pomelo.log` is too loose with its permissions.

For more information on *nix file permissions, read [this](https://unix.stackexchange.com/questions/183994/understanding-unix-permissions-and-file-types) article from my favorite Unix&Linux site.